### PR TITLE
jnmoore/fix eol bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,9 @@ A `string` with the path of the file to read.
 An `object` with the following options:
 
 - `encoding`: set the encoding. Default: `utf8`.
-- `chunk`: set the chunk size. Default is 4098.
 - `sep`: set the file separator. Default is a tabulation `\t`.
 - `empty`: set the value for the empty columns. Default is an empty string.
-- `type`: set the output type:
+- `type`: set the output type. Default is `object`.
    - `array`: each row of the table will be saved as an array object.
    - `object`: each row of the table will he saved as an object with the format `column_name : column_content`.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 //Import dependencies
-var pstat = require('pstat');
-var readl = require('readl-async');
+var fs = require('fs');
+var readline = require('readline');
 
 //Tabson object
 module.exports = function(file, opt, cb)
@@ -13,9 +13,6 @@ module.exports = function(file, opt, cb)
 
   //Check the encoding
   if(typeof opt.encoding === 'undefined'){ opt.encoding = 'utf8'; }
-
-  //Check the read chunk
-  if(typeof opt.chunk === 'undefined'){ opt.chunk = 4098; }
 
   //Check the separator
   if(typeof opt.sep === 'undefined'){ opt.sep = '\t'; }
@@ -30,13 +27,13 @@ module.exports = function(file, opt, cb)
   var out = { header: [], data: [] };
 
   //Initialize the file reader
-  var reader = new readl(file, { encoding: opt.encoding, emptyLines: false, chunk: opt.chunk });
+  var reader = readline.createInterface({ input: fs.createReadStream(file).setEncoding(opt.encoding) });
 
   //Catch the error
   reader.on('error', function(error){ return cb(error, [], []); });
 
   //Read a new line
-  reader.on('line', function(line, index)
+  reader.on('line', function(line)
   {
     //Check the header
     if(out.header.length === 0)
@@ -79,8 +76,5 @@ module.exports = function(file, opt, cb)
   });
 
   //End the file
-  reader.on('end', function(){ return cb(false, out.header, out.data); });
-
-  //Read the file
-  reader.read();
+  reader.on('close', function(){ return cb(false, out.header, out.data); });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabson",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Convert a tab file to JSON",
   "keywords": [ "tab", "tsv", "json", "tabulation" ],
   "author": "Josemi Juanes <josemijuanes@gmail.com>",


### PR DESCRIPTION
When trying to parse a TSV file exported from Google Spreadsheets, tabson would add "\r" to the last field name in the header and in the data row. Upon further inspection, this was caused by the TSF file using "\r\n" as its EOL marker. tabson only supported the "\n" EOL marker. The [readl dependency](https://www.npmjs.com/package/readl-async) does not support a multicharacter EOL marker (the attribute `endl`), since it uses string.indexOf to find the EOL marker, so I've replaced the readl library with a [readline](https://nodejs.org/api/readline.html) library. 

Verified and tested for node v0.12.7 and v6.9.4.